### PR TITLE
Consolidate SerpApiSearchException #5

### DIFF
--- a/src/Exceptions/SerpApiSearchException.php
+++ b/src/Exceptions/SerpApiSearchException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tipoff\LaravelSerpapi\Exceptions;
+
+use Exception;
+
+class SerpApiSearchException extends Exception
+{
+
+}

--- a/src/Exceptions/SerpApiSearchException.php
+++ b/src/Exceptions/SerpApiSearchException.php
@@ -6,5 +6,4 @@ use Exception;
 
 class SerpApiSearchException extends Exception
 {
-
 }

--- a/src/Helpers/SerpApiSearch.php
+++ b/src/Helpers/SerpApiSearch.php
@@ -1,9 +1,9 @@
 <?php
 
-// Exception
-class SerpApiSearchException extends Exception
-{
-}
+namespace Tipoff\LaravelSerpapi\Helpers;
+
+use RestClient;
+use Tipoff\LaravelSerpapi\Exceptions\SerpApiSearchException;
 
 /* * *
  * Google search


### PR DESCRIPTION
An issue I found when working with other packages was the errors relating to this package regarding the declaration of `SerpApiSearchException`. This I believe should solve a couple of issues with tests breaking in other packages that require this, regardless if they use it or not yet.