### PR TITLE
Remove unneeded dependency #4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "google/apiclient": "^2.7",
-        "serpapi/google-search-results-php": "^2.0",
+        "tcdent/php-restclient": "^0.1.7",
         "tipoff/authorization": "^2.0.0",
         "tipoff/support": "^1.4.10"
     },

--- a/src/LaravelSerpapiServiceProvider.php
+++ b/src/LaravelSerpapiServiceProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tipoff\LaravelSerpapi;
 
-use SerpApiSearch;
+use Tipoff\LaravelSerpapi\Helpers\SerpApiSearch;
 use Tipoff\Support\TipoffPackage;
 use Tipoff\Support\TipoffServiceProvider;
 


### PR DESCRIPTION
Since we imported most of the functional code from `serpapi/google-search-results-php` into this already, we can remove this blocking dependency.